### PR TITLE
Add DevOps Radar for November 2019

### DIFF
--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -16,6 +16,10 @@ quadrants:
         link: https://www.openpolicyagent.org/
         ring: 1
 
+      - name: 'MITRE ATT&CK'
+        link: https://attack.mitre.org/
+        ring: 2
+
   - name: CI/CD
     technologies:
 

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -57,7 +57,7 @@ quadrants:
 
       - name: Bamboo
         link: atlassian.com/software/bamboo
-        ring: 4
+        ring: 3
 
       - name: Octopus Deploy
         link: https://octopus.com/
@@ -69,7 +69,7 @@ quadrants:
 
       - name: Jenkins
         link: https://jenkins.io/
-        ring: 4
+        ring: 3
 
       - name: TeamCity
         link: https://www.jetbrains.com/teamcity/

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -12,6 +12,10 @@ quadrants:
         link: https://www.vaultproject.io/
         ring: 0
 
+      - name: Open Policy Agent
+        link: https://www.openpolicyagent.org/
+        ring: 1
+
   - name: CI/CD
     technologies:
 
@@ -59,12 +63,36 @@ quadrants:
         link: https://jenkins.io/
         ring: 3
 
-  - name: Orchestration
+      - name: TeamCity
+        link: https://www.jetbrains.com/teamcity/
+        ring: 3
+
+  - name: Orchestration & Management
     technologies:
 
       - name: Kubernetes
         link: https://kubernetes.io
         ring: 0
+
+      - name: gRPC
+        link: https://grpc.io/
+        ring: 1
+
+      - name: Envoy
+        link: https://www.envoyproxy.io/
+        ring: 1
+
+      - name: Kong
+        link: https://konghq.com/
+        ring: 1
+
+      - name: Ambassador
+        link: https://www.getambassador.io/
+        ring: 2
+
+      - name: Gloo
+        link: https://www.solo.io/
+        ring: 2
 
       - name: Knative
         link: https://knative.dev
@@ -76,20 +104,60 @@ quadrants:
       - name: Docker EE
         ring: 3
 
-  - name: Operation
+      - name: Nomad
+        link: https://www.nomadproject.io/
+        ring: 3
+
+      - name: Consul
+        link: https://www.consul.io/
+        ring: 3
+
+  - name: Observability & Analysis
     technologies:
 
       - name: Prometheus
         link: https://prometheus.io
         ring: 0
 
-      - name: Istio
-        link: https://istio.io/
-        ring: 1
+      - name: Grafana
+        link: https://grafana.com/
+        ring: 0
+
+      - name: Fluentd
+        link: https://www.fluentd.org/
+        ring: 0
 
       - name: cert-manager
         link: http://docs.cert-manager.io/en/latest/
         ring: 0
 
-      - name: Docker Hub
+      - name: Istio
+        link: https://istio.io/
+        ring: 1
+
+      - name: Kiali
+        link: https://www.kiali.io/
+        ring: 1
+
+      - name: Jaeger
+        link: https://www.jaegertracing.io/
+        ring: 1
+
+      - name: Grafana Loki
+        link: https://grafana.com/oss/loki
+        ring: 2
+
+      - name: OpenTelemetry
+        link: https://opentelemetry.io/
+        ring: 3
+
+      - name: Docker Registry
+        ring: 3
+
+      - name: Logstash
+        link: https://www.elastic.co/products/logstash
+        ring: 3
+
+      - name: Splunk
+        link: https://www.splunk.com/
         ring: 3

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -32,6 +32,14 @@ quadrants:
         link: https://splunk.com/
         ring: 3
 
+      - name: Spiffe
+        link: https://spiffe.io/
+        ring: 2
+
+      - name: Notary
+        link: https://github.com/theupdateframework/notary
+        ring: 1
+
   - name: CI/CD
     technologies:
 

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -49,7 +49,7 @@ quadrants:
 
       - name: Bamboo
         link: atlassian.com/software/bamboo
-        ring: 3
+        ring: 4
 
       - name: Octopus Deploy
         link: https://octopus.com/
@@ -61,7 +61,7 @@ quadrants:
 
       - name: Jenkins
         link: https://jenkins.io/
-        ring: 3
+        ring: 4
 
       - name: TeamCity
         link: https://www.jetbrains.com/teamcity/
@@ -111,6 +111,14 @@ quadrants:
       - name: Consul
         link: https://www.consul.io/
         ring: 3
+
+      - name: Sceptre
+        link: https://sceptre.cloudreach.com
+        ring: 3
+
+      - name: Puppet
+        link: https://puppet.com/
+        ring: 2
 
   - name: Observability & Analysis
     technologies:

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -1,3 +1,8 @@
+# ring 0 = ADOPT
+# ring 1 = TRIAL
+# ring 2 = ASSESS
+# ring 3 = HOLD
+
 version: 2019-11
 quadrants:
   - name: Security

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -23,13 +23,41 @@ quadrants:
         link: https://helm.sh
         ring: 0
 
+      - name: Jenkins X
+        link: https://jenkins-x.io/
+        ring: 1
+
+      - name: Flux
+        link: github.com/fluxcd/flux
+        ring: 1
+
       - name: Tekton
         link: https://tekton.dev
         ring: 2
 
-      - name: Jenkins X
-        link: https://jenkins-x.io/
-        ring: 1
+      - name: GitHub Actions
+        link: https://github.com/features/actions
+        ring: 2
+
+      - name: Argo
+        link: https://argoproj.github.io/
+        ring: 2
+
+      - name: Bamboo
+        link: atlassian.com/software/bamboo
+        ring: 3
+
+      - name: Octopus Deploy
+        link: https://octopus.com/
+        ring: 3
+
+      - name: Travis CI
+        link: https://travis-ci.com/
+        ring: 3
+
+      - name: Jenkins
+        link: https://jenkins.io/
+        ring: 3
 
   - name: Orchestration
     technologies:
@@ -43,6 +71,9 @@ quadrants:
         ring: 2
 
       - name: Docker Swarm
+        ring: 3
+
+      - name: Docker EE
         ring: 3
 
   - name: Operation
@@ -59,3 +90,6 @@ quadrants:
       - name: cert-manager
         link: http://docs.cert-manager.io/en/latest/
         ring: 0
+
+      - name: Docker Hub
+        ring: 3

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -20,6 +20,10 @@ quadrants:
         link: https://attack.mitre.org/
         ring: 2
 
+      - name: Falco
+        link: https://falco.org/
+        ring: 1
+
   - name: CI/CD
     technologies:
 

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -24,6 +24,14 @@ quadrants:
         link: https://falco.org/
         ring: 1
 
+      - name: Twistlock
+        link: https://twistlock.com/
+        ring: 1
+
+      - name: Splunk
+        link: https://splunk.com/
+        ring: 3
+
   - name: CI/CD
     technologies:
 
@@ -136,10 +144,6 @@ quadrants:
         link: https://puppet.com/
         ring: 1
 
-      - name: Cortex
-        link: https://github.com/cortexproject/cortex
-        ring: 1
-
       - name: Traefik
         link: https://github.com/containous/traefik
         ring: 3
@@ -205,3 +209,11 @@ quadrants:
       - name: Dynatrace
         link: https://www.dynatrace.com/
         ring: 2
+
+      - name: Cortex
+        link: https://github.com/cortexproject/cortex
+        ring: 1
+
+      - name: Thanos
+        link: https://github.com/cortexproject/thanos
+        ring: 1

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -1,13 +1,52 @@
 version: 2019-11
 quadrants:
   - name: Security
-    technologies: []
+    technologies:
+
+      - name: Vault
+        link: https://www.vaultproject.io/
+        ring: 0
 
   - name: CI/CD
-    technologies: []
+    technologies:
+
+      - name: Terraform
+        link: https://terraform.io
+        ring: 0
+
+      - name: Tekton
+        link: https://tekton.dev
+        ring: 2
+
+      - name: Jenkins X
+        link: https://jenkins-x.io/
+        ring: 1
 
   - name: Orchestration
-    technologies: []
+    technologies:
+
+      - name: Kubernetes
+        link: https://kubernetes.io
+        ring: 0
+
+      - name: Knative
+        link: https://knative.dev
+        ring: 2
+
+      - name: Docker Swarm
+        ring: 3
 
   - name: Operation
-    technologies: []
+    technologies:
+
+      - name: Prometheus
+        link: https://prometheus.io
+        ring: 0
+
+      - name: Istio
+        link: https://istio.io/
+        ring: 1
+
+      - name: cert-manager
+        link: http://docs.cert-manager.io/en/latest/
+        ring: 0

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -148,6 +148,10 @@ quadrants:
         link: https://github.com/containous/traefik
         ring: 3
 
+      - name: Kaniko
+        link: https://github.com/GoogleContainerTools/kaniko
+        ring: 2
+
   - name: Observability & Analysis
     technologies:
 

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -124,6 +124,14 @@ quadrants:
         link: https://puppet.com/
         ring: 2
 
+      - name: Cortex
+        link: https://github.com/cortexproject/cortex
+        ring: 1
+
+      - name: Traefik
+        link: https://github.com/containous/traefik
+        ring: 3
+
   - name: Observability & Analysis
     technologies:
 

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -185,3 +185,7 @@ quadrants:
       - name: Splunk
         link: https://www.splunk.com/
         ring: 3
+
+      - name: Honeycomb
+        link: https://www.honeycomb.io/
+        ring: 1

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -122,11 +122,11 @@ quadrants:
 
       - name: Sceptre
         link: https://sceptre.cloudreach.com
-        ring: 3
+        ring: 2
 
       - name: Puppet
         link: https://puppet.com/
-        ring: 2
+        ring: 1
 
       - name: Cortex
         link: https://github.com/cortexproject/cortex

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -14,6 +14,10 @@ quadrants:
         link: https://terraform.io
         ring: 0
 
+      - name: Helm
+        link: https://helm.sh
+        ring: 0
+
       - name: Tekton
         link: https://tekton.dev
         ring: 2

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -75,6 +75,14 @@ quadrants:
         link: https://www.jetbrains.com/teamcity/
         ring: 3
 
+      - name: XebiaLabs XL Deploy
+        link: https://xebialabs.com/products/deployment-automation-xl-deploy/
+        ring: 1
+
+      - name: OpenShift
+        link: https://www.openshift.com/
+        ring: 2
+
   - name: Orchestration & Management
     technologies:
 
@@ -189,3 +197,11 @@ quadrants:
       - name: Honeycomb
         link: https://www.honeycomb.io/
         ring: 1
+
+      - name: New Relic
+        link: https://newrelic.com/
+        ring: 2
+
+      - name: Dynatrace
+        link: https://www.dynatrace.com/
+        ring: 2


### PR DESCRIPTION
Add all the relevant technologies for the November 2019 DevOps Radar. Please submit your suggestions or comments.

In this edition we won't take to much time on writing down our decision but in future versions we will require a short description for each tool and why we have placed it in the given ring. But we have to start somewhere 😄 

 The EVRY DevOps Radar is a list of technologies, complemented by an assessment result, called ring assignment. We use four rings with the following semantics:

*    **ADOPT** — Technologies we have high confidence in to serve our purpose, also in large scale. Technologies with a usage culture in our EVRY production environment, low risk and recommended to be widely used.
*    **TRIAL** — Technologies that we have seen work with success in project work to solve a real problem; first serious usage experience that confirm benefits and can uncover limitations. TRIAL technologies are slightly more risky; some engineers in our organization walked this path and will share knowledge and experiences.
*    **ASSESS** — Technologies that are promising and have clear potential value-add for us; technologies worth to invest some research and prototyping efforts in to see if it has impact. ASSESS technologies have higher risks; they are often brand new and highly unproven in our organisation. You will find some engineers that have knowledge in the technology and promote it, you may even find teams that have started a prototyping effort.
*    **HOLD** — Technologies not recommended to be used for new projects. Technologies that we think are not (yet) worth to (further) invest in. HOLD technologies should not be used for new projects, but usually can be continued for existing projects.
