### PR TITLE
add clair, kube-hunter and kube-bench to the devops-radar

### DIFF
--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -40,6 +40,18 @@ quadrants:
         link: https://github.com/theupdateframework/notary
         ring: 1
 
+      - name: Clair
+        link: https://github.com/quay/clair
+        ring: 0 
+
+      - name: Kube-hunter
+        link: https://github.com/aquasecurity/kube-hunter
+        ring: 2 
+
+      - name: Kube-bench 
+        link: https://github.com/aquasecurity/kube-bench
+        ring: 1 
+      
   - name: CI/CD
     technologies:
 

--- a/_data/radar.yaml
+++ b/_data/radar.yaml
@@ -46,7 +46,7 @@ quadrants:
 
       - name: Kube-hunter
         link: https://github.com/aquasecurity/kube-hunter
-        ring: 2 
+        ring: 1 
 
       - name: Kube-bench 
         link: https://github.com/aquasecurity/kube-bench


### PR DESCRIPTION
Add Clair, kube-bench and kube-hunter to the devops radar. 

- Clair is a mature container scanning tool and is among other thing packaged with Harbour, which is a CNCF graduate
- Both kube-hunter and kube-bench are in ring 1 due to their maturity. Personally I don't think they're ready for "mainstream" adoption, but should be considered when performing cluster hardening and security assessments. 
